### PR TITLE
add database connection config

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -3,6 +3,7 @@ target/
 .mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/
+application-local.properties
 
 ### STS ###
 .apt_generated

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,6 @@
 spring.application.name=hotel-booking
+spring.datasource.url=jdbc:mysql://localhost:3306/hoteldb
+spring.datasource.username=hotel
+spring.datasource.password=root
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.show-sql=true


### PR DESCRIPTION
Connects the Spring Boot backend to the local MariaDB database.

    Add datasource config in application.properties (URL, JPA settings)
    Keep DB credentials out of version control: username and password
    live in application-local.properties (gitignored)
    Run schema.sql then seed.sql to set up the database locally, will be added to README