### PR TITLE
Feature/u2 room api

### DIFF
--- a/backend/src/main/java/at/technikum/hotel_booking/domain/port/RoomRepository.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/domain/port/RoomRepository.java
@@ -2,15 +2,9 @@ package at.technikum.hotel_booking.domain.port;
 import java.util.List;
 import java.util.Optional;
 
-import at.technikum.hotel_booking.domain.model.BookingPeriod;
-import at.technikum.hotel_booking.domain.model.Extra;
 import at.technikum.hotel_booking.domain.model.Room;
-import at.technikum.hotel_booking.domain.model.RoomImage;
 
 public interface RoomRepository {
     List<Room> findAll();
     Optional<Room> findById(Long id);
-    List<Room> findAvailableRooms(BookingPeriod period);
-    List<Extra> findExtrasForRoom(Long roomId);
-    List<RoomImage> findImagesForRoom(Long roomId);
 }

--- a/backend/src/main/java/at/technikum/hotel_booking/infrastructure/entity/RoomEntity.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/infrastructure/entity/RoomEntity.java
@@ -20,7 +20,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
 @Entity
-@Table(name = "room")
+@Table(name = "rooms")
 public class RoomEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/at/technikum/hotel_booking/infrastructure/mapper/ExtraEntityMapper.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/infrastructure/mapper/ExtraEntityMapper.java
@@ -1,23 +1,21 @@
 package at.technikum.hotel_booking.infrastructure.mapper;
 
-import at.technikum.hotel_booking.domain.model.RoomImage;
-import at.technikum.hotel_booking.infrastructure.entity.RoomImageEntity;
+import at.technikum.hotel_booking.domain.model.Extra;
 
-public final class RoomImageEntityMapper {
-    private RoomImageEntityMapper() {
+public final class ExtraEntityMapper {
+    private ExtraEntityMapper() {
         // Private constructor to prevent instantiation
     }
-    public static RoomImage toDomain(RoomImageEntity roomImageEntity) {
-        if (roomImageEntity == null) {
+    
+    public static Extra toDomain(at.technikum.hotel_booking.infrastructure.entity.ExtraEntity extraEntity) {
+        if (extraEntity == null) {
             return null;
         }
-        return new RoomImage(
-                roomImageEntity.getId(),
-                roomImageEntity.getUrl(),
-                roomImageEntity.getAltText(),
-                roomImageEntity.isMainImage(),
-                roomImageEntity.getImageOrder(),
-                roomImageEntity.getRoom() != null ? roomImageEntity.getRoom().getId() : null
+        return new Extra(
+                extraEntity.getId(),
+                extraEntity.getName(),
+                extraEntity.getDescription(),
+                extraEntity.getIconName()
         );
     }
 }

--- a/backend/src/main/java/at/technikum/hotel_booking/infrastructure/mapper/RoomEntityMapper.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/infrastructure/mapper/RoomEntityMapper.java
@@ -4,7 +4,6 @@ package at.technikum.hotel_booking.infrastructure.mapper;
 import at.technikum.hotel_booking.domain.model.Room;
 import at.technikum.hotel_booking.infrastructure.entity.RoomEntity;
 
-import java.util.List;
 
 public final class RoomEntityMapper {
    private RoomEntityMapper() {
@@ -17,8 +16,8 @@ public final class RoomEntityMapper {
         }
         return new Room(
                 roomEntity.getId(),
-                roomEntity.getNumber(),
-                roomEntity.getType(),
+                roomEntity.getTitle(),
+                roomEntity.getDescription(),
                 roomEntity.getPricePerNight(),
                 roomEntity.getCapacity(),
                 roomEntity.getSizeSqm(),

--- a/backend/src/main/java/at/technikum/hotel_booking/infrastructure/mapper/RoomImageEntityMapper.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/infrastructure/mapper/RoomImageEntityMapper.java
@@ -13,11 +13,9 @@ public final class RoomImageEntityMapper {
         }
         return new RoomImage(
                 roomImageEntity.getId(),
-                roomImageEntity.getUrl(),
-                roomImageEntity.getAltText(),
-                roomImageEntity.isMainImage(),
+                roomImageEntity.getImageUrl(),
                 roomImageEntity.getImageOrder(),
-                roomImageEntity.getRoom() != null ? roomImageEntity.getRoom().getId() : null
+                roomImageEntity.isMainImage()
         );
     }
 }

--- a/backend/src/main/java/at/technikum/hotel_booking/infrastructure/repository/RoomJpaRepository.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/infrastructure/repository/RoomJpaRepository.java
@@ -1,0 +1,8 @@
+package at.technikum.hotel_booking.infrastructure.repository;
+
+import at.technikum.hotel_booking.infrastructure.entity.RoomEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoomJpaRepository extends JpaRepository<RoomEntity,Long>{
+    
+}

--- a/backend/src/main/java/at/technikum/hotel_booking/infrastructure/repository/RoomRepositoryAdapter.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/infrastructure/repository/RoomRepositoryAdapter.java
@@ -1,0 +1,27 @@
+package at.technikum.hotel_booking.infrastructure.repository;
+
+import at.technikum.hotel_booking.infrastructure.entity.RoomEntity;
+import at.technikum.hotel_booking.infrastructure.mapper.RoomEntityMapper;
+
+@Component
+public class RoomRepositoryAdapter implements RoomRepository{
+    private final RoomJpaRepository jpa;
+
+    public RoomRepositoryAdapter(RoomJpaRepository jpa){
+        this.jpa=jpa;
+    }
+
+    @Override
+    public List<Room> findAll(){
+        List <Room> rooms= new ArrayList<>();
+        for (RoomEntity entity : jpa.findAll) {
+            rooms.add(RoomEntityMapper.toDomain(entity));
+        }
+        return rooms;
+    }
+
+    @Override
+    public Optional<Room> findById(Long id){
+        return jpa.findById(id).map(RoomEntityMapper::toDomain);
+    }
+}

--- a/backend/src/main/java/at/technikum/hotel_booking/infrastructure/repository/RoomRepositoryAdapter.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/infrastructure/repository/RoomRepositoryAdapter.java
@@ -1,5 +1,13 @@
 package at.technikum.hotel_booking.infrastructure.repository;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import at.technikum.hotel_booking.domain.model.Room;
+import at.technikum.hotel_booking.domain.port.RoomRepository;
 import at.technikum.hotel_booking.infrastructure.entity.RoomEntity;
 import at.technikum.hotel_booking.infrastructure.mapper.RoomEntityMapper;
 
@@ -14,7 +22,7 @@ public class RoomRepositoryAdapter implements RoomRepository{
     @Override
     public List<Room> findAll(){
         List <Room> rooms= new ArrayList<>();
-        for (RoomEntity entity : jpa.findAll) {
+        for (RoomEntity entity : jpa.findAll()) {
             rooms.add(RoomEntityMapper.toDomain(entity));
         }
         return rooms;

--- a/backend/src/main/java/at/technikum/hotel_booking/web/controller/RoomController.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/web/controller/RoomController.java
@@ -1,0 +1,36 @@
+package at.technikum.hotel_booking.web.controller;
+
+import java.util.ArrayList;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import at.technikum.hotel_booking.service.RoomService;
+import at.technikum.hotel_booking.web.mapper.RoomWebMapper;
+
+@RestController
+@RequestMapping("/api/rooms")
+public class RoomController {
+    private final RoomService roomService;
+    public RoomController (RoomService roomService){
+        this.roomService=roomService;
+    }
+
+    @GetMapping
+    public List<RoomResponse> getAllRooms(){
+        List<RoomResponse> result = new ArrayList<>();
+        for(Room room : roomService.getRooms()){
+            result.add(RoomWebMapper.toResponse(room));
+        }
+        return result;
+    }
+
+    @GetMapping("/{id}")
+    public RoomResponse getRoomById(@PathVariable Long id){
+        Room room = roomService.getRoomById(id);
+        return RoomWebMapper.toResponse(room);
+    }
+
+}

--- a/backend/src/main/java/at/technikum/hotel_booking/web/controller/RoomController.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/web/controller/RoomController.java
@@ -1,13 +1,16 @@
 package at.technikum.hotel_booking.web.controller;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import at.technikum.hotel_booking.domain.model.Room;
 import at.technikum.hotel_booking.service.RoomService;
+import at.technikum.hotel_booking.web.dto.RoomResponse;
 import at.technikum.hotel_booking.web.mapper.RoomWebMapper;
 
 @RestController

--- a/backend/src/main/java/at/technikum/hotel_booking/web/dto/ExtraResponse.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/web/dto/ExtraResponse.java
@@ -1,0 +1,7 @@
+package at.technikum.hotel_booking.web.dto;
+
+public record ExtraResponse(
+    Long id,
+    String name,
+    String iconName
+){}

--- a/backend/src/main/java/at/technikum/hotel_booking/web/dto/RoomImageResonse.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/web/dto/RoomImageResonse.java
@@ -1,0 +1,7 @@
+package at.technikum.hotel_booking.web.dto;
+
+public record RoomImageResponse(
+    Long id,
+    String filePath,
+    boolean isPriamry
+){}

--- a/backend/src/main/java/at/technikum/hotel_booking/web/dto/RoomImageResponse.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/web/dto/RoomImageResponse.java
@@ -2,6 +2,6 @@ package at.technikum.hotel_booking.web.dto;
 
 public record RoomImageResponse(
     Long id,
-    String filePath,
-    boolean isPriamry
+    String url,
+    boolean isMainImage
 ){}

--- a/backend/src/main/java/at/technikum/hotel_booking/web/dto/RoomResponse.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/web/dto/RoomResponse.java
@@ -1,0 +1,15 @@
+package at.technikum.hotel_booking.web.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record RoomResponse(
+    Long id,
+    String title,
+    String description,
+    BigDecimal pricePerNight,
+    int capacity,
+    int sizeSqm,
+    List<RoomImageResponse> images,
+    List<ExtraResponse> extras
+){}

--- a/backend/src/main/java/at/technikum/hotel_booking/web/mapper/RoomWebMapper.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/web/mapper/RoomWebMapper.java
@@ -1,0 +1,51 @@
+package at.technikum.hotel_booking.web.mapper;
+
+import at.technikum.hotel_booking.domain.model.*;
+import at.technikum.hotel_booking.web.dto.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class RoomWebMapper{
+    private RoomWebMapper(){
+
+    }
+    
+    public static RoomResponse toResponse(Room room){
+        List<RoomImageResponse> images = new ArrayList<>();
+        for(RoomImage image : room.getImages()){
+            images.add(toResponse(image));
+        }
+
+        List<ExtraResponse> extras = new ArrayList<>();
+        for(Extra extra : room.getExtras()){
+            extras.add(toResponse(extra));
+        }
+
+        return new RoomResponse(
+            room.getId,
+            room.getTitle,
+            room.getDescription(),
+            room.getPricePerNight(),
+            room.getCapacity(),
+            room.getSizeSqm(),
+            images,
+            extras
+        );
+    }
+
+    private static RoomImageResponse toResponse(RoomImage image){
+        return new RoomImageResponse(
+            image.getId(),
+            image.getFilePath(),
+            image.isPriamry()
+        );
+    }
+
+    private static ExtraResponse toResponse(Extra extra){
+        return new ExtraResponse(
+            extra.getId(),
+            extra.getName(),
+            extra.getIconName()
+        );
+    }
+}

--- a/backend/src/main/java/at/technikum/hotel_booking/web/mapper/RoomWebMapper.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/web/mapper/RoomWebMapper.java
@@ -1,9 +1,14 @@
 package at.technikum.hotel_booking.web.mapper;
 
-import at.technikum.hotel_booking.domain.model.*;
-import at.technikum.hotel_booking.web.dto.*;
 import java.util.ArrayList;
 import java.util.List;
+
+import at.technikum.hotel_booking.domain.model.Extra;
+import at.technikum.hotel_booking.domain.model.Room;
+import at.technikum.hotel_booking.domain.model.RoomImage;
+import at.technikum.hotel_booking.web.dto.ExtraResponse;
+import at.technikum.hotel_booking.web.dto.RoomImageResponse;
+import at.technikum.hotel_booking.web.dto.RoomResponse;
 
 public final class RoomWebMapper{
     private RoomWebMapper(){
@@ -22,8 +27,8 @@ public final class RoomWebMapper{
         }
 
         return new RoomResponse(
-            room.getId,
-            room.getTitle,
+            room.getId(),
+            room.getTitle(),
             room.getDescription(),
             room.getPricePerNight(),
             room.getCapacity(),
@@ -36,8 +41,8 @@ public final class RoomWebMapper{
     private static RoomImageResponse toResponse(RoomImage image){
         return new RoomImageResponse(
             image.getId(),
-            image.getFilePath(),
-            image.isPriamry()
+            image.getUrl(),
+            image.isMainImage()
         );
     }
 


### PR DESCRIPTION
Implements the backend side of User Story U2: guests can see an
overview of the hotel rooms and view a single room in detail.

What's included:
- GET /api/rooms         returns all rooms as a JSON list
- GET /api/rooms/{id}    returns one room by id, or 404 if missing

Architecture follows the clean architecture layers we discussed in
class:

- domain/model contains plain Java objects (Room, Extra, RoomImage)
  with no framework annotations
- domain/port defines the RoomRepository interface
- service holds RoomService as the U2 use case
- infrastructure contains the JPA entities, the Spring Data repository
  (RoomJpaRepository), the adapter that implements the port, and
  separate mappers for Room, Extra and RoomImage
- web exposes RoomController plus response DTOs (RoomResponse,
  ExtraResponse, RoomImageResponse) implemented as Java records, and
  a RoomWebMapper translating domain objects into DTOs

Not in scope of this PR:
- pagination (handled client-side, see U2.4)
- U3 availability check
- frontend for U2