### PR TITLE
implement booking creation endpoint for U4

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.compile.nullAnalysis.mode": "automatic"
+}

--- a/backend/sql/schema.sql
+++ b/backend/sql/schema.sql
@@ -41,5 +41,9 @@ CREATE TABLE IF NOT EXISTS bookings (
     room_id   BIGINT NOT NULL,
     check_in  DATE   NOT NULL,
     check_out DATE   NOT NULL,
+    first_name VARCHAR(100) NOT NULL,
+    last_name  VARCHAR(100) NOT NULL,
+    email      VARCHAR(255) NOT NULL,
+    breakfast  BOOLEAN      NOT NULL DEFAULT FALSE,
     CONSTRAINT fk_bookings_room FOREIGN KEY (room_id) REFERENCES rooms (id)
 );

--- a/backend/sql/seed.sql
+++ b/backend/sql/seed.sql
@@ -56,7 +56,7 @@ INSERT INTO room_extras (room_id, extra_id) VALUES
     (6, 1), (6, 2), (6, 5), (6, 6);
 
 -- Pre-baked unavailability for July 2026 to mirror the prototype
-INSERT INTO bookings (room_id, check_in, check_out) VALUES
-    (1, '2026-07-02', '2026-07-05'),
-    (1, '2026-07-17', '2026-07-19'),
-    (1, '2026-07-25', '2026-07-27');
+INSERT INTO bookings (room_id, check_in, check_out, first_name, last_name, email, breakfast) VALUES
+    (1, '2026-07-02', '2026-07-05', 'Elaa', 'Ezzine', 'seed@example.com', TRUE),
+    (1, '2026-07-17', '2026-07-19', 'Chiara', 'Steiner', 'seed@example.com', FALSE),
+    (1, '2026-07-25', '2026-07-27', 'Max', 'Mustermann', 'seed@example.com', FALSE);

--- a/backend/src/main/java/at/technikum/hotel_booking/config/WebConfig.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/config/WebConfig.java
@@ -2,6 +2,7 @@ package at.technikum.hotel_booking.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.lang.NonNull;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -12,7 +13,7 @@ public class WebConfig {
     public WebMvcConfigurer corsConfigurer() {
         return new WebMvcConfigurer() {
             @Override
-            public void addCorsMappings(CorsRegistry registry) {
+            public void addCorsMappings(@NonNull CorsRegistry registry) {
                 registry.addMapping("/api/**")
                         .allowedOrigins(
                                 "http://localhost:8100",

--- a/backend/src/main/java/at/technikum/hotel_booking/domain/model/Booking.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/domain/model/Booking.java
@@ -1,0 +1,60 @@
+package at.technikum.hotel_booking.domain.model;
+
+import java.time.LocalDate;
+
+public class Booking {
+    private final Long id;
+    private final Long roomId;
+    private final LocalDate checkIn;
+    private final LocalDate checkOut;
+    private final String firstName;
+    private final String lastName;
+    private final String email;
+    private final boolean breakfast;
+
+    public Booking(Long id, Long roomId, LocalDate checkIn, LocalDate checkOut, String firstName, String lastName,
+            String email, boolean breakfast) {
+        this.id = id;
+        this.roomId = roomId;
+        this.checkIn = checkIn;
+        this.checkOut = checkOut;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.email = email;
+        this.breakfast = breakfast;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getRoomId() {
+        return roomId;
+    }
+
+    public LocalDate getCheckIn() {
+        return checkIn;
+    }
+
+    public LocalDate getCheckOut() {
+        return checkOut;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public boolean isBreakfast() {
+        return breakfast;
+    }
+
+    
+}

--- a/backend/src/main/java/at/technikum/hotel_booking/domain/port/BookingRepository.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/domain/port/BookingRepository.java
@@ -2,8 +2,10 @@ package at.technikum.hotel_booking.domain.port;
 import java.time.LocalDate;
 import java.util.List;
 
+import at.technikum.hotel_booking.domain.model.Booking;
 import at.technikum.hotel_booking.domain.model.BookingPeriod;
 
 public interface BookingRepository{
     List<BookingPeriod> findOverlappingBookings(Long roomId, LocalDate checkInDate, LocalDate checkOutDate);
+    Booking save(Booking booking);
 }

--- a/backend/src/main/java/at/technikum/hotel_booking/infrastructure/entity/BookingEntity.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/infrastructure/entity/BookingEntity.java
@@ -29,10 +29,18 @@ public class BookingEntity {
     @Column(name = "check_out", nullable = false)
     private LocalDate checkOut;
 
-    // TODO U4: breakfast_included (boolean) hinzufuegen.
-    // TODO U4: status als Enum (confirmed, paid, cancelled, completed) hinzufuegen.
-    // TODO U4: price_at_booking (BigDecimal) hinzufuegen, damit der Preis zum Buchungszeitpunkt erhalten bleibt.
-    
+   @Column(name = "first_name", nullable = false)
+    private String firstName;
+
+    @Column(name = "last_name", nullable = false)
+    private String lastName;
+
+    @Column(name = "email", nullable = false)
+    private String email;
+
+    @Column(name = "breakfast", nullable = false)
+    private boolean breakfast;
+
     public Long getId() {
         return id;
     }
@@ -64,5 +72,39 @@ public class BookingEntity {
     public void setCheckOut(LocalDate checkOut) {
         this.checkOut = checkOut;
     }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public boolean isBreakfast() {
+        return breakfast;
+    }
+
+    public void setBreakfast(boolean breakfast) {
+        this.breakfast = breakfast;
+    }
+
+    
 
 }

--- a/backend/src/main/java/at/technikum/hotel_booking/infrastructure/mapper/BookingEntityMapper.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/infrastructure/mapper/BookingEntityMapper.java
@@ -1,0 +1,38 @@
+package at.technikum.hotel_booking.infrastructure.mapper;
+
+import at.technikum.hotel_booking.domain.model.Booking;
+import at.technikum.hotel_booking.web.dto.BookingResponse;
+import at.technikum.hotel_booking.web.dto.CreateBookingRequest;
+
+public final class BookingEntityMapper {
+    
+    private BookingEntityMapper(){
+
+    }
+
+    public static Booking toDomain(CreateBookingRequest request){
+        return new Booking(
+            null, //DB vergibt sie
+            request.roomId(),
+            request.checkIn(), 
+            request.checkOut(), 
+            request.firstName(), 
+            request.lastName(), 
+            request.email(), 
+            request.breakfast()
+        );
+    }
+
+    public static BookingResponse toResponse(Booking booking){
+        return new BookingResponse(
+            booking.getId(),
+            booking.getRoomId(),
+            booking.getCheckIn(),
+            booking.getCheckOut(),
+            booking.getFirstName(),
+            booking.getLastName(),
+            booking.getEmail(),
+            booking.isBreakfast()
+        );
+    }
+}

--- a/backend/src/main/java/at/technikum/hotel_booking/infrastructure/repository/BookingRepositoryAdapter.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/infrastructure/repository/BookingRepositoryAdapter.java
@@ -1,20 +1,24 @@
 package at.technikum.hotel_booking.infrastructure.repository;
 
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import at.technikum.hotel_booking.domain.model.Booking;
 import at.technikum.hotel_booking.domain.model.BookingPeriod;
 import at.technikum.hotel_booking.domain.port.BookingRepository;
 import at.technikum.hotel_booking.infrastructure.entity.BookingEntity;
-import org.springframework.stereotype.Component;
-
-import java.time.LocalDate;
-import java.util.List;
 
 @Component
 public class BookingRepositoryAdapter implements BookingRepository {
 
+    private final RoomJpaRepository roomJpaRepository;
     private final BookingJpaRepository bookingJpaRepository;
 
-    public BookingRepositoryAdapter(BookingJpaRepository bookingJpaRepository) {
+    public BookingRepositoryAdapter(BookingJpaRepository bookingJpaRepository, RoomJpaRepository roomJpaRepository) {
         this.bookingJpaRepository = bookingJpaRepository;
+        this.roomJpaRepository = roomJpaRepository;
     }
 
     @Override
@@ -36,4 +40,29 @@ public class BookingRepositoryAdapter implements BookingRepository {
             bookingEntity.getCheckOut()
     );
 }
+
+    @Override   
+    public Booking save(Booking booking) {
+        BookingEntity entity = new BookingEntity();
+        entity.setRoom(roomJpaRepository.findById(booking.getRoomId()).orElseThrow());
+        entity.setCheckIn(booking.getCheckIn());
+        entity.setCheckOut(booking.getCheckOut());
+        entity.setFirstName(booking.getFirstName());
+        entity.setLastName(booking.getLastName());
+        entity.setEmail(booking.getEmail());
+        entity.setBreakfast(booking.isBreakfast());
+
+        BookingEntity saved = bookingJpaRepository.save(entity);
+
+        return new Booking(
+            saved.getId(),
+            saved.getRoom().getId(),
+            saved.getCheckIn(),
+            saved.getCheckOut(),
+            saved.getFirstName(),
+            saved.getLastName(),
+            saved.getEmail(),
+            saved.isBreakfast()
+        );
+    }
 }

--- a/backend/src/main/java/at/technikum/hotel_booking/service/BookingService.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/service/BookingService.java
@@ -1,0 +1,38 @@
+package at.technikum.hotel_booking.service;
+
+import org.springframework.stereotype.Service;
+
+import at.technikum.hotel_booking.domain.model.Booking;
+import at.technikum.hotel_booking.domain.port.BookingRepository;
+
+@Service
+public class BookingService {
+    
+    private final BookingRepository bookingRepository;
+    private final AvailabilityService availabilityService;
+
+    public BookingService(AvailabilityService availabilityService, BookingRepository bookingRepository) {
+        this.availabilityService = availabilityService;
+        this.bookingRepository = bookingRepository;
+    }
+
+    public Booking createBooking(Booking booking){
+        if(!booking.getCheckOut().isAfter(booking.getCheckIn())){
+            throw new InvalidBookingException("Check out must be after check in");
+        }
+
+        boolean hasConflict = !bookingRepository.findOverlappingBookings(
+            booking.getRoomId(), 
+            booking.getCheckIn(), 
+            booking.getCheckOut()
+        ).isEmpty();
+        
+        if(hasConflict){
+            throw new RoomNotAvailableException("Room is not available for the selected period");
+        }
+
+        return bookingRepository.save(booking);
+    }
+
+    
+}

--- a/backend/src/main/java/at/technikum/hotel_booking/service/InvalidBookingException.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/service/InvalidBookingException.java
@@ -1,0 +1,7 @@
+package at.technikum.hotel_booking.service;
+
+public class InvalidBookingException extends RuntimeException {
+    public InvalidBookingException(String message){
+        super(message);
+    }
+}

--- a/backend/src/main/java/at/technikum/hotel_booking/service/RoomNotAvailableException.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/service/RoomNotAvailableException.java
@@ -1,0 +1,7 @@
+package at.technikum.hotel_booking.service;
+
+public class RoomNotAvailableException extends RuntimeException {
+    public RoomNotAvailableException(String message){
+        super(message);
+    }
+}

--- a/backend/src/main/java/at/technikum/hotel_booking/web/GlobalExceptionHandler.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/web/GlobalExceptionHandler.java
@@ -1,0 +1,36 @@
+package at.technikum.hotel_booking.web;
+
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import at.technikum.hotel_booking.service.InvalidBookingException;
+import at.technikum.hotel_booking.service.RoomNotAvailableException;
+import at.technikum.hotel_booking.service.RoomNotFoundException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+     @ExceptionHandler(RoomNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleRoomNotFound(RoomNotFoundException ex) {
+        return ResponseEntity
+            .status(HttpStatus.NOT_FOUND)
+            .body(Map.of("error", ex.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidBookingException.class)
+    public ResponseEntity<Map<String, String>> handleInvalidBooking(InvalidBookingException ex) {
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(Map.of("error", ex.getMessage()));
+    }
+
+    @ExceptionHandler(RoomNotAvailableException.class)
+    public ResponseEntity<Map<String, String>> handleRoomNotAvailable(RoomNotAvailableException ex) {
+        return ResponseEntity
+            .status(HttpStatus.CONFLICT)
+            .body(Map.of("error", ex.getMessage()));
+    }
+}

--- a/backend/src/main/java/at/technikum/hotel_booking/web/controller/BookingController.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/web/controller/BookingController.java
@@ -1,0 +1,35 @@
+package at.technikum.hotel_booking.web.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import at.technikum.hotel_booking.domain.model.Booking;
+import at.technikum.hotel_booking.infrastructure.mapper.BookingEntityMapper;
+import at.technikum.hotel_booking.service.BookingService;
+import at.technikum.hotel_booking.web.dto.BookingResponse;
+import at.technikum.hotel_booking.web.dto.CreateBookingRequest;
+import jakarta.validation.Valid;
+
+
+@RestController
+@RequestMapping("/api/bookings")
+public class BookingController {
+    private final BookingService bookingService;
+
+    public BookingController(BookingService bookingService) {
+        this.bookingService = bookingService;
+    }
+
+    @PostMapping
+    public ResponseEntity<BookingResponse> createBooking(@Valid @RequestBody CreateBookingRequest request) {
+       Booking domain = BookingEntityMapper.toDomain(request);
+       Booking saved = bookingService.createBooking(domain);
+       BookingResponse response = BookingEntityMapper.toResponse(saved);
+       return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+    
+}

--- a/backend/src/main/java/at/technikum/hotel_booking/web/dto/BookingResponse.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/web/dto/BookingResponse.java
@@ -1,0 +1,14 @@
+package at.technikum.hotel_booking.web.dto;
+
+import java.time.LocalDate;
+
+public record BookingResponse(
+    Long id,
+    Long roomId,
+    LocalDate checkIn,
+    LocalDate checkout,
+    String firstName,
+    String lastName,
+    String email,
+    boolean breakfast
+) {}

--- a/backend/src/main/java/at/technikum/hotel_booking/web/dto/CreateBookingRequest.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/web/dto/CreateBookingRequest.java
@@ -1,0 +1,16 @@
+package at.technikum.hotel_booking.web.dto;
+
+import java.time.LocalDate;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateBookingRequest( @NotNull Long roomId,
+    @NotNull LocalDate checkIn,
+    @NotNull LocalDate checkOut,
+    @NotBlank String firstName,
+    @NotBlank String lastName,
+    @NotBlank @Email String email,
+    boolean breakfast) {
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,8 +1,6 @@
 spring.application.name=hotel-booking
-
+spring.profiles.active=local
 spring.datasource.url=jdbc:mariadb://localhost:3306/hoteldb
-spring.datasource.username=root
-spring.datasource.password=
 
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=true

--- a/frontend/.vite/deps/_metadata.json
+++ b/frontend/.vite/deps/_metadata.json
@@ -1,0 +1,8 @@
+{
+  "hash": "9859e178",
+  "configHash": "57129bfc",
+  "lockfileHash": "e3b0c442",
+  "browserHash": "597296d6",
+  "optimized": {},
+  "chunks": {}
+}

--- a/frontend/.vite/deps/package.json
+++ b/frontend/.vite/deps/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
Implements User Story U4 backend: create a booking for a selected room
and period.

Endpoint:
- POST /api/bookings  creates a booking, returns 201 with the new id

Validation and error handling:
- @ Valid input validation on the request DTO (NotBlank, Email, NotNull)
- Check-out must be after check-in (400)
- Room must be available for the period (409)
- Unknown room ID returns 404

Structure follows the existing clean architecture layers (domain port,
service, infrastructure adapter, web controller and mappers).

Also adds a GlobalExceptionHandler with @RestControllerAdvice that
maps domain exceptions to proper HTTP status codes, replacing the
default whitelabel error responses. This also improves error handling
for the existing RoomNotFoundException from U2.

Schema change: bookings table extended with first_name, last_name,
email, breakfast columns. Seed data updated accordingly.