### PR TITLE
add booking lookup endpoint for U5 confirmation page

### DIFF
--- a/backend/src/main/java/at/technikum/hotel_booking/domain/port/BookingRepository.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/domain/port/BookingRepository.java
@@ -1,6 +1,7 @@
 package at.technikum.hotel_booking.domain.port;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import at.technikum.hotel_booking.domain.model.Booking;
 import at.technikum.hotel_booking.domain.model.BookingPeriod;
@@ -8,4 +9,5 @@ import at.technikum.hotel_booking.domain.model.BookingPeriod;
 public interface BookingRepository{
     List<BookingPeriod> findOverlappingBookings(Long roomId, LocalDate checkInDate, LocalDate checkOutDate);
     Booking save(Booking booking);
+    Optional<Booking> findById(Long id);
 }

--- a/backend/src/main/java/at/technikum/hotel_booking/infrastructure/repository/BookingRepositoryAdapter.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/infrastructure/repository/BookingRepositoryAdapter.java
@@ -2,6 +2,7 @@ package at.technikum.hotel_booking.infrastructure.repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 
@@ -64,5 +65,20 @@ public class BookingRepositoryAdapter implements BookingRepository {
             saved.getEmail(),
             saved.isBreakfast()
         );
+    }
+
+    @Override
+    public Optional<Booking> findById(Long id) {
+        return bookingJpaRepository.findById(id)
+            .map(entity -> new Booking(
+                entity.getId(), 
+                entity.getRoom().getId(), 
+                entity.getCheckIn(), 
+                entity.getCheckOut(), 
+                entity.getFirstName(), 
+                entity.getLastName(),
+                entity.getEmail(), 
+                entity.isBreakfast()
+            ));
     }
 }

--- a/backend/src/main/java/at/technikum/hotel_booking/service/BookingNotFoundException.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/service/BookingNotFoundException.java
@@ -1,0 +1,7 @@
+package at.technikum.hotel_booking.service;
+
+public class BookingNotFoundException extends RuntimeException {
+    public BookingNotFoundException(String message){
+        super(message);
+    }
+}

--- a/backend/src/main/java/at/technikum/hotel_booking/service/BookingService.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/service/BookingService.java
@@ -9,10 +9,8 @@ import at.technikum.hotel_booking.domain.port.BookingRepository;
 public class BookingService {
     
     private final BookingRepository bookingRepository;
-    private final AvailabilityService availabilityService;
 
-    public BookingService(AvailabilityService availabilityService, BookingRepository bookingRepository) {
-        this.availabilityService = availabilityService;
+    public BookingService(BookingRepository bookingRepository) {
         this.bookingRepository = bookingRepository;
     }
 
@@ -34,5 +32,9 @@ public class BookingService {
         return bookingRepository.save(booking);
     }
 
-    
+    public Booking getBookingById(Long id){
+        return bookingRepository.findById(id)
+            .orElseThrow(() -> new BookingNotFoundException("Booking with id "+id+" not found"));
+    }
+
 }

--- a/backend/src/main/java/at/technikum/hotel_booking/web/GlobalExceptionHandler.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/web/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import at.technikum.hotel_booking.service.InvalidBookingException;
 import at.technikum.hotel_booking.service.RoomNotAvailableException;
 import at.technikum.hotel_booking.service.RoomNotFoundException;
+import at.technikum.hotel_booking.service.BookingNotFoundException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -33,4 +34,11 @@ public class GlobalExceptionHandler {
             .status(HttpStatus.CONFLICT)
             .body(Map.of("error", ex.getMessage()));
     }
+
+    @ExceptionHandler(BookingNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleBookingNotFound(BookingNotFoundException ex) {
+    return ResponseEntity
+        .status(HttpStatus.NOT_FOUND)
+        .body(Map.of("error", ex.getMessage()));
+    }  
 }

--- a/backend/src/main/java/at/technikum/hotel_booking/web/controller/BookingController.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/web/controller/BookingController.java
@@ -13,6 +13,9 @@ import at.technikum.hotel_booking.service.BookingService;
 import at.technikum.hotel_booking.web.dto.BookingResponse;
 import at.technikum.hotel_booking.web.dto.CreateBookingRequest;
 import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
 
 
 @RestController
@@ -31,5 +34,12 @@ public class BookingController {
        BookingResponse response = BookingEntityMapper.toResponse(saved);
        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
+
+    @GetMapping("/{id}")
+    public BookingResponse getBookingById(@PathVariable Long id) {
+        Booking booking = bookingService.getBookingById(id);
+        return BookingEntityMapper.toResponse(booking);
+    }
+    
     
 }


### PR DESCRIPTION
Adds a GET endpoint to retrieve a booking by id, which the
frontend confirmation page (U5) will use to display the booking
details after creation.

Endpoint:
- GET /api/bookings/{id}  returns the booking, or 404 if not found

Includes a new BookingNotFoundException mapped to HTTP 404 in the
GlobalExceptionHandler. Follows the same structure as the existing
GET /api/rooms/{id} endpoint.

Tested manually with curl for found and not-found cases.