### PR TITLE
add created_at and price_at_booking to bookings

### DIFF
--- a/backend/sql/schema.sql
+++ b/backend/sql/schema.sql
@@ -45,5 +45,7 @@ CREATE TABLE IF NOT EXISTS bookings (
     last_name  VARCHAR(100) NOT NULL,
     email      VARCHAR(255) NOT NULL,
     breakfast  BOOLEAN      NOT NULL DEFAULT FALSE,
+    price_at_booking DECIMAL(10,2) NOT NULL,
+    created_at TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT fk_bookings_room FOREIGN KEY (room_id) REFERENCES rooms (id)
 );

--- a/backend/sql/seed.sql
+++ b/backend/sql/seed.sql
@@ -57,6 +57,6 @@ INSERT INTO room_extras (room_id, extra_id) VALUES
 
 -- Pre-baked unavailability for July 2026 to mirror the prototype
 INSERT INTO bookings (room_id, check_in, check_out, first_name, last_name, email, breakfast) VALUES
-    (1, '2026-07-02', '2026-07-05', 'Elaa', 'Ezzine', 'seed@example.com', TRUE),
-    (1, '2026-07-17', '2026-07-19', 'Chiara', 'Steiner', 'seed@example.com', FALSE),
-    (1, '2026-07-25', '2026-07-27', 'Max', 'Mustermann', 'seed@example.com', FALSE);
+    (1, '2026-07-02', '2026-07-05', 'Elaa', 'Ezzine', 'seed@example.com', TRUE, 130.00),
+    (1, '2026-07-17', '2026-07-19', 'Chiara', 'Steiner', 'seed@example.com', FALSE, 379.90),
+    (1, '2026-07-25', '2026-07-27', 'Max', 'Mustermann', 'seed@example.com', FALSE, 250.00);

--- a/backend/src/main/java/at/technikum/hotel_booking/domain/model/Booking.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/domain/model/Booking.java
@@ -1,6 +1,9 @@
 package at.technikum.hotel_booking.domain.model;
 
+import java.math.BigDecimal;
+import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public class Booking {
     private final Long id;
@@ -11,9 +14,11 @@ public class Booking {
     private final String lastName;
     private final String email;
     private final boolean breakfast;
+    private final BigDecimal priceAtBooking;
+    private final LocalDateTime createdAt;
 
     public Booking(Long id, Long roomId, LocalDate checkIn, LocalDate checkOut, String firstName, String lastName,
-            String email, boolean breakfast) {
+            String email, boolean breakfast,BigDecimal priceAtBooking, LocalDateTime createdAt) {
         this.id = id;
         this.roomId = roomId;
         this.checkIn = checkIn;
@@ -22,6 +27,8 @@ public class Booking {
         this.lastName = lastName;
         this.email = email;
         this.breakfast = breakfast;
+        this.priceAtBooking= priceAtBooking;
+        this.createdAt= createdAt;
     }
 
     public Long getId() {
@@ -56,5 +63,11 @@ public class Booking {
         return breakfast;
     }
 
+    public BigDecimal getPriceAtBooking(){
+        return priceAtBooking;
+    }
+    public LocalDateTime getCreatedAt(){
+        return createdAt;
+    }
     
 }

--- a/backend/src/main/java/at/technikum/hotel_booking/infrastructure/entity/BookingEntity.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/infrastructure/entity/BookingEntity.java
@@ -1,6 +1,8 @@
 package at.technikum.hotel_booking.infrastructure.entity;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -40,7 +42,14 @@ public class BookingEntity {
 
     @Column(name = "breakfast", nullable = false)
     private boolean breakfast;
-
+    
+    @Column(name = "price_at_booking", nullable = false)
+    private BigDecimal priceAtBooking;
+    
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @org.hibernate.annotations.CreationTimestamp
+    private LocalDateTime createdAt;    
+    
     public Long getId() {
         return id;
     }
@@ -103,6 +112,22 @@ public class BookingEntity {
 
     public void setBreakfast(boolean breakfast) {
         this.breakfast = breakfast;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public BigDecimal getPriceAtBooking() {
+        return priceAtBooking;
+    }
+
+    public void setPriceAtBooking(BigDecimal priceAtBooking) {
+        this.priceAtBooking = priceAtBooking;
     }
 
     

--- a/backend/src/main/java/at/technikum/hotel_booking/infrastructure/mapper/BookingEntityMapper.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/infrastructure/mapper/BookingEntityMapper.java
@@ -19,7 +19,9 @@ public final class BookingEntityMapper {
             request.firstName(), 
             request.lastName(), 
             request.email(), 
-            request.breakfast()
+            request.breakfast(),
+            null,
+            null
         );
     }
 
@@ -32,7 +34,9 @@ public final class BookingEntityMapper {
             booking.getFirstName(),
             booking.getLastName(),
             booking.getEmail(),
-            booking.isBreakfast()
+            booking.isBreakfast(),
+            booking.getPriceAtBooking(),
+            booking.getCreatedAt()
         );
     }
 }

--- a/backend/src/main/java/at/technikum/hotel_booking/infrastructure/repository/BookingRepositoryAdapter.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/infrastructure/repository/BookingRepositoryAdapter.java
@@ -52,6 +52,7 @@ public class BookingRepositoryAdapter implements BookingRepository {
         entity.setLastName(booking.getLastName());
         entity.setEmail(booking.getEmail());
         entity.setBreakfast(booking.isBreakfast());
+        entity.setPriceAtBooking(booking.getPriceAtBooking());
 
         BookingEntity saved = bookingJpaRepository.save(entity);
 
@@ -63,7 +64,9 @@ public class BookingRepositoryAdapter implements BookingRepository {
             saved.getFirstName(),
             saved.getLastName(),
             saved.getEmail(),
-            saved.isBreakfast()
+            saved.isBreakfast(),
+            saved.getPriceAtBooking(),
+            saved.getCreatedAt()
         );
     }
 
@@ -78,7 +81,9 @@ public class BookingRepositoryAdapter implements BookingRepository {
                 entity.getFirstName(), 
                 entity.getLastName(),
                 entity.getEmail(), 
-                entity.isBreakfast()
+                entity.isBreakfast(),
+                entity.getPriceAtBooking(),
+                entity.getCreatedAt()
             ));
     }
 }

--- a/backend/src/main/java/at/technikum/hotel_booking/service/BookingService.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/service/BookingService.java
@@ -1,17 +1,24 @@
 package at.technikum.hotel_booking.service;
 
-import org.springframework.stereotype.Service;
+import java.math.BigDecimal;
 
-import at.technikum.hotel_booking.domain.model.Booking;
+import java.time.temporal.ChronoUnit;
+
+import org.springframework.stereotype.Service;
 import at.technikum.hotel_booking.domain.port.BookingRepository;
+import at.technikum.hotel_booking.domain.port.RoomRepository;
+import at.technikum.hotel_booking.domain.model.Booking;
+import at.technikum.hotel_booking.domain.model.Room;
 
 @Service
 public class BookingService {
     
     private final BookingRepository bookingRepository;
+    private final RoomRepository roomRepository;
 
-    public BookingService(BookingRepository bookingRepository) {
+    public BookingService(BookingRepository bookingRepository, RoomRepository roomRepository) {
         this.bookingRepository = bookingRepository;
+        this.roomRepository = roomRepository;
     }
 
     public Booking createBooking(Booking booking){
@@ -29,7 +36,26 @@ public class BookingService {
             throw new RoomNotAvailableException("Room is not available for the selected period");
         }
 
-        return bookingRepository.save(booking);
+        Room room = roomRepository.findById(booking.getRoomId())
+            .orElseThrow(()-> new RoomNotFoundException("Room with id "+booking.getRoomId()+" not found"));
+        
+        long nights = ChronoUnit.DAYS.between(booking.getCheckIn(), booking.getCheckOut());
+        BigDecimal totalPrice = room.getPricePerNight().multiply(BigDecimal.valueOf(nights));
+        
+        Booking withPrice = new Booking(
+            booking.getId(),
+            booking.getRoomId(),
+            booking.getCheckIn(),
+            booking.getCheckOut(),
+            booking.getFirstName(),
+            booking.getLastName(),
+            booking.getEmail(),
+            booking.isBreakfast(),
+            totalPrice,
+            booking.getCreatedAt()
+        );
+
+        return bookingRepository.save(withPrice);
     }
 
     public Booking getBookingById(Long id){

--- a/backend/src/main/java/at/technikum/hotel_booking/web/dto/BookingResponse.java
+++ b/backend/src/main/java/at/technikum/hotel_booking/web/dto/BookingResponse.java
@@ -1,6 +1,8 @@
 package at.technikum.hotel_booking.web.dto;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public record BookingResponse(
     Long id,
@@ -10,5 +12,7 @@ public record BookingResponse(
     String firstName,
     String lastName,
     String email,
-    boolean breakfast
+    boolean breakfast,
+    BigDecimal priceAtBooking,
+    LocalDateTime createdAt
 ) {}

--- a/backend/src/test/java/at/technikum/hotelbooking/HotelBookingApplicationTests.java
+++ b/backend/src/test/java/at/technikum/hotelbooking/HotelBookingApplicationTests.java
@@ -1,4 +1,4 @@
-package at.technikum.hotel_booking;
+package at.technikum.hotelbooking;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/backend/src/test/java/at/technikum/hotelbooking/service/BookingServiceTest.java
+++ b/backend/src/test/java/at/technikum/hotelbooking/service/BookingServiceTest.java
@@ -1,0 +1,143 @@
+package at.technikum.hotelbooking.service;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import org.mockito.Mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import at.technikum.hotelbooking.domain.model.Booking;
+import at.technikum.hotelbooking.domain.model.BookingPeriod;
+import at.technikum.hotelbooking.domain.model.Room;
+import at.technikum.hotelbooking.domain.port.BookingRepository;
+import at.technikum.hotelbooking.domain.port.RoomRepository;
+
+@ExtendWith(MockitoExtension.class) //for @mock annotation to create a fake object
+public class BookingServiceTest {
+    
+    @Mock
+    private BookingRepository bookingRepository; 
+
+    @Mock
+    private RoomRepository roomRepository;
+    
+    private BookingService bookingService;
+
+    @BeforeEach
+    void setUp(){
+        bookingService = new BookingService(bookingRepository, roomRepository);
+    }
+
+    @Test
+    void createBooking_shouldThrow_whenCheckOutIsBeforeCheckIn(){
+        Booking invalidBooking = new Booking(
+            null, 
+            1L, 
+            LocalDate.of(2026,10,5), 
+            LocalDate.of(2026,10,3), 
+            "Max", 
+            "Mustermann", 
+            "mm@test.com", 
+            false, 
+            null, 
+            null
+        );
+
+        assertThatThrownBy(()-> bookingService.createBooking(invalidBooking))
+            .isInstanceOf(InvalidBookingException.class)
+            .hasMessageContaining("Check out must be after check in");
+    }
+
+    @Test
+    void createBooking_shouldThrow_whenRoomisNotAvailable(){
+        Booking validDates = new Booking(
+            null, 
+            1L, 
+            LocalDate.of(2026,10,1), 
+            LocalDate.of(2026,10,5), 
+            "Max", 
+            "Mustermann", 
+            "mm@test.com", 
+            false, 
+            null, 
+            null
+        );
+
+        BookingPeriod existingBooking= new BookingPeriod(LocalDate.of(2026,10,2), LocalDate.of(2026,10,4));
+
+        when(bookingRepository.findOverlappingBookings(anyLong(), any(), any()))
+            .thenReturn(List.of(existingBooking));
+
+        assertThatThrownBy(()-> bookingService.createBooking(validDates))
+            .isInstanceOf(RoomNotAvailableException.class)
+            .hasMessageContaining("Room is not available");
+    }
+
+    @Test
+    void createBooking_shouldCalculatePriceAndSave_whenValid() {
+        Booking incomingBooking = new Booking(
+            null,
+            1L,
+            LocalDate.of(2026, 10, 1),
+            LocalDate.of(2026, 10, 5),
+            "Test",
+            "User",
+            "test@example.com",
+            false,
+            null,
+            null
+        );
+
+        Room mockedRoom = new Room(
+            1L,
+            "Test Room",
+            "Description",
+            new BigDecimal("100.00"),
+            2,
+            20,
+            Collections.emptyList(),
+            Collections.emptyList()
+        );
+
+        Booking savedBooking = new Booking(
+            42L,
+            1L,
+            LocalDate.of(2026, 10, 1),
+            LocalDate.of(2026, 10, 5),
+            "Test",
+            "User",
+            "test@example.com",
+            false,
+            new BigDecimal("400.00"),
+            null
+        );
+
+        when(bookingRepository.findOverlappingBookings(anyLong(), any(), any()))
+            .thenReturn(Collections.emptyList());
+        when(roomRepository.findById(1L))
+            .thenReturn(Optional.of(mockedRoom));
+        when(bookingRepository.save(any(Booking.class)))
+            .thenReturn(savedBooking);
+
+        Booking result = bookingService.createBooking(incomingBooking);
+
+        assertThat(result.getId()).isEqualTo(42L);
+        assertThat(result.getPriceAtBooking()).isEqualByComparingTo("400.00");
+        assertThat(result.getFirstName()).isEqualTo("Test");
+        
+        verify(bookingRepository).save(any(Booking.class));
+    }
+
+}


### PR DESCRIPTION
Adds two new columns to the bookings table to support the confirmation page in U5 and basic audit:
- created_at: timestamp set by the database via DEFAULT CURRENT_TIMESTAMP, mapped in JPA with @CreationTimestamp so Hibernate populates the field on insert without needing a reload from the database.
- price_at_booking: the total price (price per night times number of nights) calculated by the backend. The frontend does not send the price to prevent client-side manipulations
- check-out before check-in throws InvalidBookingException
- overlapping booking throws RoomNotAvailableException  
- valid booking is saved with calculated price