### PR TITLE
add swagger ui documentation with springdoc-openapi

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -57,6 +57,11 @@
 		<artifactId>h2</artifactId>
 		<scope>test</scope>
 	</dependency>
+	<dependency>
+		<groupId>org.springdoc</groupId>
+		<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+		<version>2.6.0</version>
+	</dependency>
 </dependencies>
 	<build>
 		<plugins>

--- a/backend/src/main/java/at/technikum/hotelbooking/config/OpenApiConfig.java
+++ b/backend/src/main/java/at/technikum/hotelbooking/config/OpenApiConfig.java
@@ -1,0 +1,22 @@
+package at.technikum.hotelbooking.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+
+@Configuration
+public class OpenApiConfig {
+    @Bean
+    public OpenAPI hotelBookingOpenAPI() {
+        return new OpenAPI()
+            .info(new Info()
+                .title("ACE Escapes Hotel Booking API")
+                .description("REST API for the Boutique Hotel Technikum booking app")
+                .version("1.0.0")
+                .contact(new Contact()
+                    .name("ACE Escapes Team")));
+    }
+}

--- a/backend/src/main/java/at/technikum/hotelbooking/web/controller/AvailabilityController.java
+++ b/backend/src/main/java/at/technikum/hotelbooking/web/controller/AvailabilityController.java
@@ -16,9 +16,12 @@ import at.technikum.hotelbooking.domain.model.BookingPeriod;
 import at.technikum.hotelbooking.service.AvailabilityService;
 import at.technikum.hotelbooking.service.RoomService;
 import at.technikum.hotelbooking.web.dto.AvailabilityResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
+@Tag(name = "Availability", description = "Check room availability for a given period")
 @RestController
-@RequestMapping("/api/rooms")
+@RequestMapping("/api/rooms/availability")
 public class AvailabilityController {
 
     private final AvailabilityService availabilityService;
@@ -32,6 +35,8 @@ public class AvailabilityController {
         this.roomService = roomService;
     }
 
+    @Operation(summary = "Check availability of a room for a given period",
+               description = "Returns whether the room is available and the total price for the period if it is available")
     @GetMapping("/{roomId}/availability")
     public AvailabilityResponse checkAvailability(
             @PathVariable Long roomId,

--- a/backend/src/main/java/at/technikum/hotelbooking/web/controller/BookingController.java
+++ b/backend/src/main/java/at/technikum/hotelbooking/web/controller/BookingController.java
@@ -14,10 +14,12 @@ import at.technikum.hotelbooking.infrastructure.mapper.BookingEntityMapper;
 import at.technikum.hotelbooking.service.BookingService;
 import at.technikum.hotelbooking.web.dto.BookingResponse;
 import at.technikum.hotelbooking.web.dto.CreateBookingRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
 
-
+@Tag(name = "Bookings", description = "Create and look up bookings")
 @RestController
 @RequestMapping("/api/bookings")
 public class BookingController {
@@ -27,6 +29,8 @@ public class BookingController {
         this.bookingService = bookingService;
     }
 
+    @Operation(summary = "Create a new booking",
+           description = "Validates dates, checks availability, calculates the total price and saves the booking")
     @PostMapping
     public ResponseEntity<BookingResponse> createBooking(@Valid @RequestBody CreateBookingRequest request) {
        Booking domain = BookingEntityMapper.toDomain(request);
@@ -35,6 +39,7 @@ public class BookingController {
        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
+    @Operation(summary = "Get a booking by id")
     @GetMapping("/{id}")
     public BookingResponse getBookingById(@PathVariable Long id) {
         Booking booking = bookingService.getBookingById(id);

--- a/backend/src/main/java/at/technikum/hotelbooking/web/controller/RoomController.java
+++ b/backend/src/main/java/at/technikum/hotelbooking/web/controller/RoomController.java
@@ -13,7 +13,11 @@ import at.technikum.hotelbooking.domain.model.Room;
 import at.technikum.hotelbooking.service.RoomService;
 import at.technikum.hotelbooking.web.dto.RoomResponse;
 import at.technikum.hotelbooking.web.mapper.RoomWebMapper;
-@CrossOrigin(origins = "http://localhost:8100")
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Rooms", description = "Get information about rooms")
+@CrossOrigin(origins = "http://localhost:8080")
 @RestController
 @RequestMapping("/api/rooms")
 public class RoomController {
@@ -22,6 +26,7 @@ public class RoomController {
         this.roomService=roomService;
     }
 
+    @Operation(summary = "Get all rooms", description = "Returns a list of all rooms with their details, images and extras")    
     @GetMapping
     public List<RoomResponse> getAllRooms(){
         List<RoomResponse> result = new ArrayList<>();
@@ -31,6 +36,7 @@ public class RoomController {
         return result;
     }
 
+    @Operation(summary = "Get a room by id", description = "Returns the details, images and extras of a specific room by its id")   
     @GetMapping("/{id}")
     public RoomResponse getRoomById(@PathVariable Long id){
         Room room = roomService.getRoomById(id);

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -7,3 +7,8 @@ spring.datasource.password=
 
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=true
+
+# OpenAPI / Swagger
+springdoc.api-docs.path=/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.swagger-ui.operationsSorter=method


### PR DESCRIPTION
Adds automatic API documentation with springdoc-openapi to address
the review feedback about the PDF docs being out of sync with the
code. The Swagger UI is generated from the controllers and stays
in sync automatically.

Documentation:
- Swagger UI: http://localhost:8080/swagger-ui.html
- OpenAPI JSON: http://localhost:8080/api-docs

Changes:
- pom.xml: springdoc-openapi-starter-webmvc-ui dependency
- application.properties: paths for api-docs and swagger-ui
- OpenApiConfig: title, description and version metadata
- Controllers: @Tag and @Operation annotations for clearer
  descriptions in the Swagger UI
- docs/API_DOCS.md: short pointer doc that explains where
  Swagger UI lives and lists the endpoints
- README.md: link updated from old PDF to Swagger UI

Path change for AvailabilityController:
- /api/[rooms] is now /api/rooms/availability
- Frontend and any external clients need to update accordingly

Old PDF documentation in Docs/ stays as historical milestone
artifacts. Swagger UI is the source of truth from now on.