### PR TITLE
Feature/code cleanup

### DIFF
--- a/backend/src/main/java/at/technikum/hotelbooking/domain/port/RoomRepository.java
+++ b/backend/src/main/java/at/technikum/hotelbooking/domain/port/RoomRepository.java
@@ -2,9 +2,11 @@ package at.technikum.hotelbooking.domain.port;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.lang.NonNull;
+
 import at.technikum.hotelbooking.domain.model.Room;
 
 public interface RoomRepository {
     List<Room> findAll();
-    Optional<Room> findById(Long id);
+    Optional<Room> findById(@NonNull Long id);
 }

--- a/backend/src/main/java/at/technikum/hotelbooking/service/AvailabilityService.java
+++ b/backend/src/main/java/at/technikum/hotelbooking/service/AvailabilityService.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import at.technikum.hotelbooking.domain.model.Availability;
 import at.technikum.hotelbooking.domain.model.BookingPeriod;
@@ -11,6 +12,7 @@ import at.technikum.hotelbooking.domain.model.Room;
 import at.technikum.hotelbooking.domain.port.BookingRepository;
 
 @Service
+@Transactional(readOnly = true)
 public class AvailabilityService {
 
     private final RoomService roomService;

--- a/backend/src/main/java/at/technikum/hotelbooking/service/BookingService.java
+++ b/backend/src/main/java/at/technikum/hotelbooking/service/BookingService.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.time.temporal.ChronoUnit;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import at.technikum.hotelbooking.domain.model.Booking;
 import at.technikum.hotelbooking.domain.model.Room;
@@ -11,6 +12,7 @@ import at.technikum.hotelbooking.domain.port.BookingRepository;
 import at.technikum.hotelbooking.domain.port.RoomRepository;
 
 @Service
+@Transactional
 public class BookingService {
     
     private final BookingRepository bookingRepository;

--- a/backend/src/main/java/at/technikum/hotelbooking/service/RoomService.java
+++ b/backend/src/main/java/at/technikum/hotelbooking/service/RoomService.java
@@ -3,11 +3,13 @@ package at.technikum.hotelbooking.service;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import at.technikum.hotelbooking.domain.model.Room;
 import at.technikum.hotelbooking.domain.port.RoomRepository;
 
 @Service
+@Transactional(readOnly =true)
 public class RoomService {
 
     private final RoomRepository roomRepository;
@@ -22,7 +24,7 @@ public class RoomService {
 
     public Room getRoomById(Long id) {
         return roomRepository.findById(id)
-                .orElseThrow(() -> new RoomNotFoundException("room not found: " + id));
+                .orElseThrow(() -> new RoomNotFoundException("Room not found: " + id));
     }
 
 }

--- a/backend/src/main/java/at/technikum/hotelbooking/web/controller/AvailabilityController.java
+++ b/backend/src/main/java/at/technikum/hotelbooking/web/controller/AvailabilityController.java
@@ -3,17 +3,17 @@ package at.technikum.hotelbooking.web.controller;
 import java.time.LocalDate;
 
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import at.technikum.hotelbooking.domain.model.Availability;
 import at.technikum.hotelbooking.domain.model.BookingPeriod;
 import at.technikum.hotelbooking.service.AvailabilityService;
+import at.technikum.hotelbooking.service.InvalidBookingException;
+import at.technikum.hotelbooking.service.RoomNotFoundException;
 import at.technikum.hotelbooking.service.RoomService;
 import at.technikum.hotelbooking.web.dto.AvailabilityResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -21,7 +21,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "Availability", description = "Check room availability for a given period")
 @RestController
-@RequestMapping("/api/rooms/availability")
+@RequestMapping("/api/rooms")
 public class AvailabilityController {
 
     private final AvailabilityService availabilityService;
@@ -55,7 +55,7 @@ public class AvailabilityController {
                 .stream()
                 .filter(item -> item.getRoomId().equals(roomId))
                 .findFirst()
-                .orElseThrow(() -> new RoomAvailabilityNotFoundException(roomId));
+                .orElseThrow(() -> new RoomNotFoundException("Room not found: "+roomId));
 
         return new AvailabilityResponse(
                 availability.getRoomId(),
@@ -67,23 +67,7 @@ public class AvailabilityController {
 
     private void validateBookingPeriod(LocalDate checkIn, LocalDate checkOut) {
         if (!checkOut.isAfter(checkIn)) {
-            throw new InvalidBookingPeriodException(
-                    "Check-out date must be after check-in date."
-            );
-        }
-    }
-
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    private static class InvalidBookingPeriodException extends RuntimeException {
-        public InvalidBookingPeriodException(String message) {
-            super(message);
-        }
-    }
-
-    @ResponseStatus(HttpStatus.NOT_FOUND)
-    private static class RoomAvailabilityNotFoundException extends RuntimeException {
-        public RoomAvailabilityNotFoundException(Long roomId) {
-            super("Availability for room not found: " + roomId);
+            throw new InvalidBookingException("Check-out date must be after check-in date.");
         }
     }
 }

--- a/backend/src/main/java/at/technikum/hotelbooking/web/controller/BookingController.java
+++ b/backend/src/main/java/at/technikum/hotelbooking/web/controller/BookingController.java
@@ -10,10 +10,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import at.technikum.hotelbooking.domain.model.Booking;
-import at.technikum.hotelbooking.infrastructure.mapper.BookingEntityMapper;
 import at.technikum.hotelbooking.service.BookingService;
 import at.technikum.hotelbooking.web.dto.BookingResponse;
 import at.technikum.hotelbooking.web.dto.CreateBookingRequest;
+import at.technikum.hotelbooking.web.mapper.BookingWebMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -33,9 +33,9 @@ public class BookingController {
            description = "Validates dates, checks availability, calculates the total price and saves the booking")
     @PostMapping
     public ResponseEntity<BookingResponse> createBooking(@Valid @RequestBody CreateBookingRequest request) {
-       Booking domain = BookingEntityMapper.toDomain(request);
+       Booking domain = BookingWebMapper.toDomain(request);
        Booking saved = bookingService.createBooking(domain);
-       BookingResponse response = BookingEntityMapper.toResponse(saved);
+       BookingResponse response = BookingWebMapper.toResponse(saved);
        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
@@ -43,7 +43,7 @@ public class BookingController {
     @GetMapping("/{id}")
     public BookingResponse getBookingById(@PathVariable Long id) {
         Booking booking = bookingService.getBookingById(id);
-        return BookingEntityMapper.toResponse(booking);
+        return BookingWebMapper.toResponse(booking);
     }
     
     

--- a/backend/src/main/java/at/technikum/hotelbooking/web/controller/RoomController.java
+++ b/backend/src/main/java/at/technikum/hotelbooking/web/controller/RoomController.java
@@ -1,6 +1,5 @@
 package at.technikum.hotelbooking.web.controller;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,11 +26,9 @@ public class RoomController {
     @Operation(summary = "Get all rooms", description = "Returns a list of all rooms with their details, images and extras")    
     @GetMapping
     public List<RoomResponse> getAllRooms(){
-        List<RoomResponse> result = new ArrayList<>();
-        for(Room room : roomService.getRooms()){
-            result.add(RoomWebMapper.toResponse(room));
-        }
-        return result;
+        return roomService.getRooms().stream()
+            .map(RoomWebMapper::toResponse)
+            .toList();
     }
 
     @Operation(summary = "Get a room by id", description = "Returns the details, images and extras of a specific room by its id")   

--- a/backend/src/main/java/at/technikum/hotelbooking/web/controller/RoomController.java
+++ b/backend/src/main/java/at/technikum/hotelbooking/web/controller/RoomController.java
@@ -3,7 +3,6 @@ package at.technikum.hotelbooking.web.controller;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,7 +16,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "Rooms", description = "Get information about rooms")
-@CrossOrigin(origins = "http://localhost:8080")
 @RestController
 @RequestMapping("/api/rooms")
 public class RoomController {

--- a/backend/src/main/java/at/technikum/hotelbooking/web/mapper/BookingWebMapper.java
+++ b/backend/src/main/java/at/technikum/hotelbooking/web/mapper/BookingWebMapper.java
@@ -1,12 +1,12 @@
-package at.technikum.hotelbooking.infrastructure.mapper;
+package at.technikum.hotelbooking.web.mapper;
 
 import at.technikum.hotelbooking.domain.model.Booking;
 import at.technikum.hotelbooking.web.dto.BookingResponse;
 import at.technikum.hotelbooking.web.dto.CreateBookingRequest;
 
-public final class BookingEntityMapper {
+public final class BookingWebMapper {
     
-    private BookingEntityMapper(){
+    private BookingWebMapper(){
 
     }
 


### PR DESCRIPTION
Cleans up several inconsistencies found while reviewing the backend against our own best practices document.

Changes:
    Added @ transactional on services. BookingService is fully
    transactional (writes), RoomService and AvailabilityService
    are @ transactional(readOnly = true) for JPA performance.
    Removed the per-controller @ crossorigin in RoomController.
    CORS is configured globally in WebConfig, the per-controller
    annotation was overriding it inconsistently.
    AvailabilityController no longer has inner exception classes.
    It now throws the existing InvalidBookingException and
    RoomNotFoundException, which are mapped centrally in
    GlobalExceptionHandler.
    Fixed the availability path. The class-level @ RequestMapping
    was /api/rooms/availability while the method-level was
    /{roomId}/availability, so the actual path had availability
    twice. Now /api/rooms/{roomId}/availability cleanly.
    BookingEntityMapper renamed to BookingWebMapper and moved to
    web/mapper. The old name and location were misleading, the
    mapper translates between DTOs and the domain, not between
    entities and the domain.
    RoomController.getAllRooms uses the Stream API instead of a
    manual loop, matching the style in AvailabilityController.

No functional changes, all endpoints behave the same except for the corrected availability path.
