### PR TITLE
add unit and integration tests for U2, U3, U5

### DIFF
--- a/backend/src/test/java/at/technikum/hotelbooking/service/AvailabilityServiceTest.java
+++ b/backend/src/test/java/at/technikum/hotelbooking/service/AvailabilityServiceTest.java
@@ -1,0 +1,75 @@
+package at.technikum.hotelbooking.service;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import at.technikum.hotelbooking.domain.model.Availability;
+import at.technikum.hotelbooking.domain.model.BookingPeriod;
+import at.technikum.hotelbooking.domain.model.Room;
+import at.technikum.hotelbooking.domain.port.BookingRepository;
+
+@ExtendWith(MockitoExtension.class)
+class AvailabilityServiceTest {
+
+    @Mock
+    private RoomService roomService;
+
+    @Mock
+    private BookingRepository bookingRepository;
+
+    private AvailabilityService availabilityService;
+
+    @BeforeEach
+    void setUp() {
+        availabilityService = new AvailabilityService(roomService, bookingRepository);
+    }
+
+    @Test
+    void checkAvailability_marksRoomAvailable_andCalculatesTotalPrice_whenNoOverlaps() {
+        BookingPeriod period = new BookingPeriod(LocalDate.of(2026, 6, 10), LocalDate.of(2026, 6, 13)); // 3 nights
+
+        Room room = new Room(1L, "R", "r", new BigDecimal("100.00"), 2, 20, Collections.emptyList(), Collections.emptyList());
+
+        when(roomService.getRooms()).thenReturn(List.of(room));
+        when(bookingRepository.findOverlappingBookings(1L, period.getCheckInDate(), period.getCheckOutDate()))
+            .thenReturn(Collections.emptyList());
+
+        List<Availability> availabilities = availabilityService.checkAvailability(period);
+
+        assertThat(availabilities).hasSize(1);
+        Availability a = availabilities.get(0);
+        assertThat(a.getRoomId()).isEqualTo(1L);
+        assertThat(a.isAvailable()).isTrue();
+        assertThat(a.getTotalPrice()).isEqualByComparingTo(new BigDecimal("100.00").multiply(BigDecimal.valueOf(period.getNumberOfNights())));
+    }
+
+    @Test
+    void checkAvailability_marksRoomNotAvailable_andTotalPriceZero_whenOverlapsExist() {
+        BookingPeriod period = new BookingPeriod(LocalDate.of(2026, 7, 1), LocalDate.of(2026, 7, 4)); // 3 nights
+
+        Room room = new Room(2L, "R2", "r2", new BigDecimal("80.00"), 2, 18, Collections.emptyList(), Collections.emptyList());
+
+        when(roomService.getRooms()).thenReturn(List.of(room));
+        when(bookingRepository.findOverlappingBookings(2L, period.getCheckInDate(), period.getCheckOutDate()))
+            .thenReturn(List.of(new BookingPeriod(LocalDate.of(2026, 7, 2), LocalDate.of(2026, 7, 3))));
+
+        List<Availability> availabilities = availabilityService.checkAvailability(period);
+
+        assertThat(availabilities).hasSize(1);
+        Availability a = availabilities.get(0);
+        assertThat(a.getRoomId()).isEqualTo(2L);
+        assertThat(a.isAvailable()).isFalse();
+        assertThat(a.getTotalPrice()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+}

--- a/backend/src/test/java/at/technikum/hotelbooking/service/RoomServiceTest.java
+++ b/backend/src/test/java/at/technikum/hotelbooking/service/RoomServiceTest.java
@@ -1,0 +1,78 @@
+package at.technikum.hotelbooking.service;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import at.technikum.hotelbooking.domain.model.Room;
+import at.technikum.hotelbooking.domain.port.RoomRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class RoomServiceTest {
+
+    @Mock
+    private RoomRepository roomRepository;
+
+    private RoomService roomService;
+
+    @BeforeEach
+    void setUp() {
+        roomService = new RoomService(roomRepository);
+    }
+
+    @Test
+    void getRoomById_returnsRoom_whenExists() {
+        Room mockedRoom = new Room(
+            1L,
+            "Test Room",
+            "Description",
+            new BigDecimal("100.00"),
+            2,
+            20,
+            Collections.emptyList(),
+            Collections.emptyList()
+        );
+
+        when(roomRepository.findById(1L)).thenReturn(Optional.of(mockedRoom));
+
+        Room result = roomService.getRoomById(1L);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(1L);
+        assertThat(result.getTitle()).isEqualTo("Test Room");
+    }
+
+    @Test
+    void getRoomById_throwsRoomNotFoundException_whenNotFound() {
+        when(roomRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> roomService.getRoomById(99L))
+            .isInstanceOf(RoomNotFoundException.class)
+            .hasMessageContaining("room not found");
+    }
+
+    @Test
+    void getRooms_returnsAllRooms() {
+        Room r1 = new Room(1L, "A", "a", new BigDecimal("50.00"), 1, 10, Collections.emptyList(), Collections.emptyList());
+        Room r2 = new Room(2L, "B", "b", new BigDecimal("75.00"), 2, 15, Collections.emptyList(), Collections.emptyList());
+
+        when(roomRepository.findAll()).thenReturn(List.of(r1, r2));
+
+        List<Room> result = roomService.getRooms();
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getId()).isEqualTo(1L);
+        assertThat(result.get(1).getId()).isEqualTo(2L);
+    }
+
+}

--- a/backend/src/test/java/at/technikum/hotelbooking/web/controller/BookingControllerIT.java
+++ b/backend/src/test/java/at/technikum/hotelbooking/web/controller/BookingControllerIT.java
@@ -9,17 +9,18 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-
-import at.technikum.hotelbooking.infrastructure.entity.RoomEntity;
-import at.technikum.hotelbooking.infrastructure.repository.RoomJpaRepository;
-
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import at.technikum.hotelbooking.infrastructure.entity.RoomEntity;
+import at.technikum.hotelbooking.infrastructure.repository.BookingJpaRepository;
+import at.technikum.hotelbooking.infrastructure.repository.RoomJpaRepository;
+
 @SpringBootTest
 @AutoConfigureMockMvc
-public class BookingControllerIT {
+class BookingControllerIT {
     
     @Autowired
     private MockMvc mockMvc;
@@ -27,10 +28,14 @@ public class BookingControllerIT {
     @Autowired
     private RoomJpaRepository roomJpaRepository;
 
+    @Autowired
+    private BookingJpaRepository bookingJpaRepository;
+
     private Long roomId;
 
     @BeforeEach
     void setUp() {
+        bookingJpaRepository.deleteAll();
         roomJpaRepository.deleteAll();
         RoomEntity room = new RoomEntity();
         room.setTitle("Integration Test Room");
@@ -63,5 +68,43 @@ public class BookingControllerIT {
             .andExpect(jsonPath("$.id").isNumber())
             .andExpect(jsonPath("$.priceAtBooking").value(400.00))
             .andExpect(jsonPath("$.firstName").value("Integration"));
+    }
+
+    @Test
+    void getBookingById_returns200_andBooking_whenExists() throws Exception {
+        String body = """
+            {
+                "roomId": %d,
+                "checkIn": "2026-12-01",
+                "checkOut": "2026-12-05",
+                "firstName": "Integration",
+                "lastName": "Test",
+                "email": "integration@example.com",
+                "breakfast": false
+            }
+            """.formatted(roomId);
+
+        var mvcResult = mockMvc.perform(post("/api/bookings")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.id").isNumber())
+            .andReturn();
+
+        String resp = mvcResult.getResponse().getContentAsString();
+        com.fasterxml.jackson.databind.JsonNode node = new com.fasterxml.jackson.databind.ObjectMapper().readTree(resp);
+        long id = node.get("id").asLong();
+
+        mockMvc.perform(get("/api/bookings/{id}", id))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value((int) id))
+            .andExpect(jsonPath("$.firstName").value("Integration"));
+    }
+
+    @Test
+    void getBookingById_returns404_whenNotFound() throws Exception {
+        mockMvc.perform(get("/api/bookings/{id}", 99999L))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.error").exists());
     }
 }

--- a/backend/src/test/java/at/technikum/hotelbooking/web/controller/RoomControllerIT.java
+++ b/backend/src/test/java/at/technikum/hotelbooking/web/controller/RoomControllerIT.java
@@ -1,0 +1,70 @@
+package at.technikum.hotelbooking.web.controller;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import at.technikum.hotelbooking.infrastructure.entity.RoomEntity;
+import at.technikum.hotelbooking.infrastructure.repository.RoomJpaRepository;
+
+@SpringBootTest(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = Replace.ANY)
+class RoomControllerIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private RoomJpaRepository roomJpaRepository;
+
+    private Long roomId;
+
+    @BeforeEach
+    void setUp() {
+        roomJpaRepository.deleteAll();
+
+        RoomEntity room = new RoomEntity();
+        room.setTitle("Integration Room A");
+        room.setDescription("Room A for integration tests");
+        room.setPricePerNight(new BigDecimal("120.00"));
+        room.setCapacity(2);
+        room.setSizeSqm(18);
+        RoomEntity saved = roomJpaRepository.save(room);
+        roomId = saved.getId();
+    }
+
+    @Test
+    void getAllRooms_returns200_withListOfRooms() throws Exception {
+        mockMvc.perform(get("/api/rooms"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].id").isNumber())
+            .andExpect(jsonPath("$[0].title").value("Integration Room A"));
+    }
+
+    @Test
+    void getRoomById_returns200_withRightRoom() throws Exception {
+        mockMvc.perform(get("/api/rooms/{id}", roomId))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(roomId.intValue()))
+            .andExpect(jsonPath("$.title").value("Integration Room A"));
+    }
+
+    @Test
+    void getRoomById_returns404_whenNotFound() throws Exception {
+        mockMvc.perform(get("/api/rooms/{id}", 99999L))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.error").exists());
+    }
+
+}


### PR DESCRIPTION
- RoomServiceTest covers getRoomById (found and not-found)  and getRooms
- AvailabilityServiceTest covers the available and not-available cases including the total price calculation
- RoomControllerIT covers GET /api/rooms and GET /api/rooms/{id} including the 404 case
- BookingControllerIT extended with GET /api/bookings/{id} for the found and not-found cases. Also added bookingJpaRepository cleanup in @BeforeEach to keep tests isolated

Tests generated with Copilot following the existing pattern from BookingServiceTest, then reviewed and adjusted (e.g. case-sensitive exception messages, redundant test annotations removed).